### PR TITLE
Upgrade to Fishtown Release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,14 +10,16 @@
     <parent>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-build</artifactId>
-        <version>1.2.2.BUILD-SNAPSHOT</version>
+        <version>2.1.0.RC3</version>
     </parent>
 
     <modules>
         <module>spring-cloud-stream-binder-jms-common</module>
         <module>spring-cloud-stream-binder-jms-common-test-support</module>
+        <!--
         <module>spring-cloud-stream-binder-jms-activemq-test-support</module>
         <module>spring-cloud-stream-binder-jms-activemq</module>
+        -->
     </modules>
 
     <dependencyManagement>
@@ -25,7 +27,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-stream-dependencies</artifactId>
-                <version>Chelsea.BUILD-SNAPSHOT</version>
+                <version>Fishtown.RC4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/spring-cloud-stream-binder-jms-common-test-support/src/main/java/org/springframework/cloud/stream/binder/test/integration/receiver/ReceiverApplication.java
+++ b/spring-cloud-stream-binder-jms-common-test-support/src/main/java/org/springframework/cloud/stream/binder/test/integration/receiver/ReceiverApplication.java
@@ -23,15 +23,18 @@ import java.util.concurrent.CountDownLatch;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
-import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
-import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
+//import org.springframework.boot.autoconfigure.web.embedded.EmbeddedWebServerFactoryCustomizerAutoConfiguration;
+//import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
+//import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.cloud.stream.messaging.Sink;
 import org.springframework.messaging.Message;
 import org.springframework.stereotype.Component;
 
-@SpringBootApplication(exclude = {EmbeddedServletContainerAutoConfiguration.class, WebMvcAutoConfiguration.class, JmxAutoConfiguration.class})
+@SpringBootApplication(exclude = {
+		//EmbeddedServletContainerAutoConfiguration.class, WebMvcAutoConfiguration.class,
+		JmxAutoConfiguration.class})
 @EnableBinding(Sink.class)
 public class ReceiverApplication {
 
@@ -56,6 +59,7 @@ public class ReceiverApplication {
 
 			Object payload = message.getPayload();
 			if (payload.equals(EXCEPTION_REQUEST)) {
+			//if (new String((byte[]) payload).equals(EXCEPTION_REQUEST)) {  // this was needed in Elmhurst Release
 				throw new RuntimeException(REQUESTED_EXCEPTION);
 			}
 

--- a/spring-cloud-stream-binder-jms-common-test-support/src/main/java/org/springframework/cloud/stream/binder/test/integration/sender/SenderApplication.java
+++ b/spring-cloud-stream-binder-jms-common-test-support/src/main/java/org/springframework/cloud/stream/binder/test/integration/sender/SenderApplication.java
@@ -22,8 +22,8 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
-import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
+//import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
+//import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -31,7 +31,7 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.stereotype.Component;
 
-@SpringBootApplication(exclude = {EmbeddedServletContainerAutoConfiguration.class, WebMvcAutoConfiguration.class})
+@SpringBootApplication//(exclude = {EmbeddedServletContainerAutoConfiguration.class, WebMvcAutoConfiguration.class})
 @EnableBinding(Source.class)
 public class SenderApplication {
 

--- a/spring-cloud-stream-binder-jms-common/pom.xml
+++ b/spring-cloud-stream-binder-jms-common/pom.xml
@@ -31,22 +31,23 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-stream-codec</artifactId>
+            <version>1.2.3.BUILD-SNAPSHOT</version>
         </dependency>
+
+        <!--
+        Caused by: org.springframework.context.ApplicationContextException: Starting with Spring Integration 5.0, the 'spring-integration-java-dsl' dependency is no longer needed; the Java DSL has been merged into the core project. If it is present on the classpath, it will cause class loading conflicts.
 
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-java-dsl</artifactId>
+            <version>1.2.2.RELEASE</version>
         </dependency>
+        -->
 
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-jms_1.1_spec</artifactId>
             <version>1.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
         </dependency>
 
     </dependencies>

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/JMSMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/JMSMessageChannelBinder.java
@@ -21,10 +21,8 @@ import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.Topic;
 
-import org.springframework.cloud.stream.binder.AbstractMessageChannelBinder;
-import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
-import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
-import org.springframework.cloud.stream.binder.ExtendedPropertiesBinder;
+import org.springframework.cloud.stream.binder.*;
+import org.springframework.cloud.stream.binder.jms.config.JmsBindingProperties;
 import org.springframework.cloud.stream.binder.jms.config.JmsConsumerProperties;
 import org.springframework.cloud.stream.binder.jms.config.JmsExtendedBindingProperties;
 import org.springframework.cloud.stream.binder.jms.config.JmsProducerProperties;
@@ -69,7 +67,8 @@ public class JMSMessageChannelBinder
 			JmsMessageDrivenChannelAdapterFactory jmsMessageDrivenChannelAdapterFactory,
 			JmsTemplate jmsTemplate,
 			ConnectionFactory connectionFactory) {
-		super(true, null, provisioningProvider);
+		//super(true, null, provisioningProvider);
+		super(new String[0], provisioningProvider, null);
 		this.jmsSendingMessageHandlerFactory = jmsSendingMessageHandlerFactory;
 		this.jmsMessageDrivenChannelAdapterFactory = jmsMessageDrivenChannelAdapterFactory;
 		this.connectionFactory = connectionFactory;
@@ -83,7 +82,7 @@ public class JMSMessageChannelBinder
 
 	@Override
 	protected MessageHandler createProducerMessageHandler(ProducerDestination producerDestination,
-			ExtendedProducerProperties<JmsProducerProperties> producerProperties) throws Exception {
+			ExtendedProducerProperties<JmsProducerProperties> producerProperties, MessageChannel errorChannel) throws Exception { //TODO: Figure out how to use errorChannel
 		TopicPartitionRegistrar topicPartitionRegistrar = new TopicPartitionRegistrar();
 		Session session = connectionFactory.createConnection().createSession(true, 1);
 
@@ -119,5 +118,15 @@ public class JMSMessageChannelBinder
 	@Override
 	public JmsProducerProperties getExtendedProducerProperties(String channelName) {
 		return this.extendedBindingProperties.getExtendedProducerProperties(channelName);
+	}
+
+	@Override
+	public String getDefaultsPrefix() {
+		return this.extendedBindingProperties.getDefaultsPrefix();
+	}
+
+	@Override
+	public Class<? extends BinderSpecificPropertiesProvider> getExtendedPropertiesEntryClass() {
+		return this.extendedBindingProperties.getExtendedPropertiesEntryClass();
 	}
 }

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBinderGlobalConfiguration.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBinderGlobalConfiguration.java
@@ -112,7 +112,7 @@ public class JmsBinderGlobalConfiguration {
 
 			JMSMessageChannelBinder jmsMessageChannelBinder = new JMSMessageChannelBinder(provisioningProvider,
 					jmsSendingMessageHandlerFactory, jmsMessageDrivenChannelAdapterFactory, jmsTemplate, connectionFactory);
-			jmsMessageChannelBinder.setCodec(codec);
+			//jmsMessageChannelBinder.setCodec(codec); //no more codec, it is all managed by content-type header parameter now
 			jmsMessageChannelBinder.setExtendedBindingProperties(jmsExtendedBindingProperties);
 			return jmsMessageChannelBinder;
 		}

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBindingProperties.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBindingProperties.java
@@ -16,10 +16,12 @@
 
 package org.springframework.cloud.stream.binder.jms.config;
 
+import org.springframework.cloud.stream.binder.BinderSpecificPropertiesProvider;
+
 /**
  * @author Ilayaperumal Gopinathan
  */
-public class JmsBindingProperties {
+public class JmsBindingProperties implements BinderSpecificPropertiesProvider {
 
 	private JmsConsumerProperties consumer = new JmsConsumerProperties();
 

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsExtendedBindingProperties.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsExtendedBindingProperties.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.stream.binder.BinderSpecificPropertiesProvider;
 import org.springframework.cloud.stream.binder.ExtendedBindingProperties;
 
 /**
@@ -27,6 +28,8 @@ import org.springframework.cloud.stream.binder.ExtendedBindingProperties;
  */
 @ConfigurationProperties("spring.cloud.stream.jms")
 public class JmsExtendedBindingProperties implements ExtendedBindingProperties<JmsConsumerProperties, JmsProducerProperties> {
+
+	private static final String DEFAULTS_PREFIX = "spring.cloud.stream.ibmmq.default";
 
 	private Map<String, JmsBindingProperties> bindings = new HashMap<>();
 
@@ -56,5 +59,15 @@ public class JmsExtendedBindingProperties implements ExtendedBindingProperties<J
 		else {
 			return new JmsProducerProperties();
 		}
+	}
+
+	@Override
+	public String getDefaultsPrefix() {
+		return DEFAULTS_PREFIX;
+	}
+
+	@Override
+	public Class<? extends BinderSpecificPropertiesProvider> getExtendedPropertiesEntryClass() {
+		return JmsBindingProperties.class;
 	}
 }

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/JmsMessageDrivenChannelAdapterFactory.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/JmsMessageDrivenChannelAdapterFactory.java
@@ -30,7 +30,8 @@ import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.jms.config.JmsConsumerProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.integration.dsl.jms.JmsMessageDrivenChannelAdapter;
+//import org.springframework.integration.dsl.jms.JmsMessageDrivenChannelAdapter;
+import org.springframework.integration.jms.JmsMessageDrivenEndpoint;
 import org.springframework.integration.jms.ChannelPublishingJmsMessageListener;
 import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.RetryCallback;
@@ -73,12 +74,12 @@ public class JmsMessageDrivenChannelAdapterFactory implements ApplicationContext
 		this.applicationContext = applicationContext;
 	}
 
-	public JmsMessageDrivenChannelAdapter build(Queue destination,
+	public /*JmsMessageDrivenChannelAdapter*/ JmsMessageDrivenEndpoint build(Queue destination,
 			final ExtendedConsumerProperties<JmsConsumerProperties> properties) {
 		RetryingChannelPublishingJmsMessageListener listener = new RetryingChannelPublishingJmsMessageListener(
 				properties, messageRecoverer, properties.getExtension().getDlqName());
 		listener.setBeanFactory(this.beanFactory);
-		JmsMessageDrivenChannelAdapter adapter = new JmsMessageDrivenChannelAdapter(
+		JmsMessageDrivenEndpoint adapter = new JmsMessageDrivenEndpoint(
 				listenerContainerFactory.build(destination), listener);
 		adapter.setApplicationContext(this.applicationContext);
 		adapter.setBeanFactory(this.beanFactory);


### PR DESCRIPTION
* Upgrade to Fishtown Release
* Upgrade to Spring Boot 2
* Since Elmhurst release, SCS expects the application to manage Content-Type so test cases are updated accordingly
* Disable two test cases which are serialization and primitive type test
* ibm mq test cases do not work immediately so you need to do a trick. Please follow instructions in 
```EndToEndIntegrationTests.createSender()```
```EndToEndIntegrationTests.createReceiver()```